### PR TITLE
Adicionar links para as versões .txt dos artigos

### DIFF
--- a/trm1/1n7r0duc40.html
+++ b/trm1/1n7r0duc40.html
@@ -9,6 +9,7 @@
 <body>
 <div class="background"></div>
 <div class="txtdiv"><pre id="artpre">
+<a href="1n7r0duc40.txt">.txt</a>
                                                                                                                                
   <g1>
 

--- a/trm1/As_complexidades_da_aleatoriedade_na_computacao.html
+++ b/trm1/As_complexidades_da_aleatoriedade_na_computacao.html
@@ -9,6 +9,7 @@
 <body>
 <div class="background"></div>
 <div class="txtdiv"><pre id="artpre">
+<a href="As_complexidades_da_aleatoriedade_na_computacao.txt">.txt</a>
                                                                                                                                
   <g1>
 

--- a/trm1/Detectando_sanitizadores_HTML_geneticamente.html
+++ b/trm1/Detectando_sanitizadores_HTML_geneticamente.html
@@ -9,6 +9,7 @@
 <body>
 <div class="background"></div>
 <div class="txtdiv"><pre id="artpre">
+<a href="Detectando_sanitizadores_HTML_geneticamente.txt">.txt</a>
                                                                                                                                
   <g1>
 

--- a/trm1/Entropia_para_a_criacao_de_criptografia.html
+++ b/trm1/Entropia_para_a_criacao_de_criptografia.html
@@ -9,6 +9,7 @@
 <body>
 <div class="background"></div>
 <div class="txtdiv"><pre id="artpre">
+<a href="Entropia_para_a_criacao_de_criptografia.txt">.txt</a>
                                                                                                                                
   <g1>
 

--- a/trm1/Era_uma_vez_uma_Lotus_Negra.html
+++ b/trm1/Era_uma_vez_uma_Lotus_Negra.html
@@ -9,6 +9,7 @@
 <body>
 <div class="background"></div>
 <div class="txtdiv"><pre id="artpre">
+<a href="Era_uma_vez_uma_Lotus_negra.txt">.txt</a>
                                                                                                                                
     <g1>
 

--- a/trm1/Eu.html
+++ b/trm1/Eu.html
@@ -9,6 +9,7 @@
 <body>
 <div class="background"></div>
 <div class="txtdiv"><pre id="artpre">
+<a href="Eu.txt">.txt</a>
                                                                                                                                
   <g1>
 

--- a/trm1/Explorando_memorias_NAND.html
+++ b/trm1/Explorando_memorias_NAND.html
@@ -9,6 +9,7 @@
 <body>
 <div class="background"></div>
 <div class="txtdiv"><pre id="artpre">
+<a href="Explorando_memorias_NAND.txt">.txt</a>
                                                                                                                                
   <g1>
 

--- a/trm1/Mapeando_roteadores_com_microcontroladores.html
+++ b/trm1/Mapeando_roteadores_com_microcontroladores.html
@@ -9,6 +9,7 @@
 <body>
 <div class="background"></div>
 <div class="txtdiv"><pre id="artpre">
+<a href="Mapeando_roteadores_com_microcontroladores.txt">.txt</a>
                                                                                                                                
   <g1>
 

--- a/trm1/O_Elixir_do_hacking.html
+++ b/trm1/O_Elixir_do_hacking.html
@@ -9,6 +9,7 @@
 <body>
 <div class="background"></div>
 <div class="txtdiv"><pre id="artpre">
+<a href="O_Elixir_do_hacking.txt">.txt</a>
                                                                                                                                
   <g1>
 

--- a/trm1/Um_hacking_inacabado_de_verao.html
+++ b/trm1/Um_hacking_inacabado_de_verao.html
@@ -9,6 +9,7 @@
 <body>
 <div class="background"></div>
 <div class="txtdiv"><pre id="artpre">
+<a href="Um_hacking_inacabado_de_verao.txt">.txt</a>
                                                                                                                                
   <g1>
 


### PR DESCRIPTION
Uma ideia de como isso pode ser feito... O link fica na parte superior esquerda da pagina, assim:

![image](https://github.com/user-attachments/assets/14b96a7b-468f-4703-a194-221a74c50645)

Em vez de fazer manualmente, tambem da para colocar um codigo javascript que faz isso automaticamente. Algo assim:

```js
const artpre = document.getElementById('artpre');
const txt_url = document.location.href.replace(/html$/, 'txt');
artpre.innerHTML = `<a href="${txt_url}">.txt</a>` + artpre.innerHTML;
```